### PR TITLE
Replace custom Mapbox style with standard outdoors style

### DIFF
--- a/react-native/constants/map.ts
+++ b/react-native/constants/map.ts
@@ -1,7 +1,7 @@
 // Map constants
 export const INITIAL_ZOOM = 10.5;
 export const INITIAL_CENTER = [-120.713, 47.585]; // Note: [longitude, latitude] in React Native
-export const STYLE_URI = "mapbox://styles/nathanhadley/clw9fowlu01kw01obbpsp3wiq";
+export const STYLE_URI = "mapbox://styles/mapbox/outdoors-v12";
 export const PROBLEMS_LAYER = "leavenworth-problems";
 export const MAPBOX_ACCESS_TOKEN =
   "pk.eyJ1IjoibmF0aGFuaGFkbGV5IiwiYSI6ImNsdzdmdXAxdDIycmoyanA3cXVvbHFxenQifQ.1wcBxvOkH8eU-6ev7SoO8Q";


### PR DESCRIPTION
- Boulder drawings now rely entirely on local vector layer rendering instead of custom style

🤖 Generated with [Claude Code](https://claude.ai/code)