### PR TITLE
Fix about screen scroll view height on Android

### DIFF
--- a/react-native/screens/AboutScreen/index.tsx
+++ b/react-native/screens/AboutScreen/index.tsx
@@ -93,8 +93,8 @@ export default function AboutScreen() {
   return (
     <SafeAreaView className="flex-1 bg-background-0">
       <ScrollView
-        className="flex-1"
-        contentContainerStyle={{ paddingBottom: tabBarHeight }}
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingBottom: tabBarHeight, flexGrow: 1 }}
         showsVerticalScrollIndicator={false}
       >
         <View className="px-6 py-8">


### PR DESCRIPTION
## Summary
Fixes an issue where the ScrollView in the About screen only occupied ~1/5 of the screen height on some Android devices, leaving the rest black.

## Changes
- Replace `className="flex-1"` with `style={{flex: 1}}` on ScrollView
- Add `flexGrow: 1` to `contentContainerStyle` to ensure proper expansion
- Ensures ScrollView uses full available screen space consistently across devices

## Root Cause
The issue was caused by React Native's flex layout behavior on Android when using NativeWind classes vs inline styles. The ScrollView wasn't properly expanding to fill the SafeAreaView container.

## Test plan
- [ ] Verify CI passes
- [ ] Test on Android devices that previously showed the issue
- [ ] Confirm ScrollView now uses full screen height
- [ ] Check that scrolling behavior remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)