### PR TITLE
Add grade filter functionality to map search

### DIFF
--- a/react-native/components/GradeFilter.tsx
+++ b/react-native/components/GradeFilter.tsx
@@ -1,0 +1,62 @@
+import { ScrollView, TouchableOpacity } from "react-native";
+import { Badge, BadgeText, HStack, VStack, Text } from "@/components/ui";
+import { useProblemStore } from "@/stores/problemStore";
+import { X } from "lucide-react-native";
+
+const AVAILABLE_GRADES = ["V0", "V1", "V2", "V3", "V4", "V5", "V6", "V7", "V8", "V9"];
+
+export default function GradeFilter() {
+  const { selectedGrades, toggleGrade, setSelectedGrades } = useProblemStore();
+
+  const handleClearAll = () => {
+    setSelectedGrades([]);
+  };
+
+  const hasFilters = selectedGrades.length > 0;
+
+  return (
+    <VStack className="p-4 bg-white border-t border-gray-200">
+      <HStack className="justify-between items-center mb-3">
+        <Text className="font-semibold text-gray-900">Filter by Grade</Text>
+        {hasFilters && (
+          <TouchableOpacity onPress={handleClearAll} className="flex-row items-center">
+            <X size={16} color="#6B7280" />
+            <Text className="ml-1 text-sm text-gray-600">Clear</Text>
+          </TouchableOpacity>
+        )}
+      </HStack>
+      
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <HStack className="gap-2">
+          {AVAILABLE_GRADES.map((grade) => {
+            const isSelected = selectedGrades.includes(grade);
+            return (
+              <TouchableOpacity
+                key={grade}
+                onPress={() => toggleGrade(grade)}
+                activeOpacity={0.7}
+              >
+                <Badge
+                  className={`px-3 py-1 ${
+                    isSelected 
+                      ? 'bg-blue-500 border-blue-500' 
+                      : 'bg-gray-100 border-gray-300'
+                  }`}
+                  variant={isSelected ? "solid" : "outline"}
+                >
+                  <BadgeText
+                    className={`text-sm font-medium ${
+                      isSelected ? 'text-white' : 'text-gray-700'
+                    }`}
+                  >
+                    {grade}
+                  </BadgeText>
+                </Badge>
+              </TouchableOpacity>
+            );
+          })}
+        </HStack>
+      </ScrollView>
+    </VStack>
+  );
+}

--- a/react-native/screens/MapScreen/index.tsx
+++ b/react-native/screens/MapScreen/index.tsx
@@ -11,6 +11,7 @@ import { ProblemView } from "./ProblemView";
 import { LocateMeButton } from "../../components/buttons/LocateMeButton";
 import { MapSearchBar } from "../../components/MapSearchBar";
 import { SearchOverlay } from "../SearchScreen";
+import GradeFilter from "../../components/GradeFilter";
 import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 import {
   BouldersLayer,
@@ -93,6 +94,13 @@ export function MapScreen() {
 
       {/* Search Bar */}
       {!isSearchVisible && <MapSearchBar onPress={() => setIsSearchVisible(true)} />}
+
+      {/* Grade Filter */}
+      {!isSearchVisible && !viewProblem && (
+        <View className="absolute top-20 left-0 right-0 z-10">
+          <GradeFilter />
+        </View>
+      )}
 
       <LocateMeButton
         onPress={centerToUserLocation}

--- a/react-native/screens/MapScreen/layers/ProblemsLayer.tsx
+++ b/react-native/screens/MapScreen/layers/ProblemsLayer.tsx
@@ -1,14 +1,29 @@
 import { problemsData } from "@/assets/problems";
 import { CircleLayer, ShapeSource, SymbolLayer } from "@rnmapbox/maps";
 import { PROBLEM_COLORS } from "@/constants/map";
+import { useProblemStore } from "@/stores/problemStore";
+import { useMemo } from "react";
 
 export function ProblemsLayer() {
+  const { selectedGrades } = useProblemStore();
+  
   if (!problemsData) return null;
+
+  // Create filter expression for selected grades
+  const gradeFilter = useMemo(() => {
+    if (selectedGrades.length === 0) {
+      return true; // Show all problems when no grades are selected
+    }
+    
+    // Create an "in" expression for the selected grades
+    return ["in", ["get", "grade"], ["literal", selectedGrades]];
+  }, [selectedGrades]);
 
   return (
     <ShapeSource id="problems-source" shape={problemsData}>
       <CircleLayer
         id="problems-layer"
+        filter={gradeFilter}
         style={{
           circleRadius: ["interpolate", ["linear"], ["zoom"], 16, 3, 22, 20],
           circleColor: [
@@ -39,6 +54,7 @@ export function ProblemsLayer() {
       />
       <SymbolLayer
         id="problems-text-layer"
+        filter={gradeFilter}
         style={{
           textField: ["get", "order"],
           textSize: ["interpolate", ["linear"], ["zoom"], 17, 8, 22, 26],

--- a/react-native/screens/SearchScreen/index.tsx
+++ b/react-native/screens/SearchScreen/index.tsx
@@ -27,7 +27,7 @@ type SearchResult = {
 export function SearchOverlay({ isVisible, onClose }: SearchOverlayProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
-  const { createProblemFromMapFeature, setProblem, setViewProblem } = useProblemStore();
+  const { createProblemFromMapFeature, setProblem, setViewProblem, selectedGrades } = useProblemStore();
   const { flyToProblemCoordinates } = useMapStore();
   const { colorScheme } = useColorScheme();
 
@@ -45,6 +45,11 @@ export function SearchOverlay({ isVisible, onClose }: SearchOverlayProps) {
     problemsData.features.forEach(feature => {
       const problem = createProblemFromMapFeature(feature);
       if (!problem) return;
+
+      // Apply grade filter if grades are selected
+      if (selectedGrades.length > 0 && problem.grade && !selectedGrades.includes(problem.grade)) {
+        return;
+      }
 
       if (problem.name?.toLowerCase().includes(searchTerm)) {
         results.push({ problem, matchType: "name" });

--- a/react-native/stores/problemStore.ts
+++ b/react-native/stores/problemStore.ts
@@ -15,10 +15,13 @@ type ProblemState = {
   // State
   problem: Problem | null;
   viewProblem: boolean;
+  selectedGrades: string[];
 
   // Actions
   setProblem: (problem: Problem | null) => void;
   setViewProblem: (view: boolean) => void;
+  setSelectedGrades: (grades: string[]) => void;
+  toggleGrade: (grade: string) => void;
   getProblem: (params: GetProblemParams) => Problem | null;
   showPreviousProblem: () => void;
   showNextProblem: () => void;
@@ -31,10 +34,19 @@ export const useProblemStore = create<ProblemState>((set, get) => ({
   // Initial state
   problem: null,
   viewProblem: false,
+  selectedGrades: [],
 
   // Actions
   setProblem: (problem: Problem | null) => set({ problem }),
   setViewProblem: (view: boolean) => set({ viewProblem: view }),
+  setSelectedGrades: (grades: string[]) => set({ selectedGrades: grades }),
+  toggleGrade: (grade: string) => {
+    const { selectedGrades } = get();
+    const newGrades = selectedGrades.includes(grade)
+      ? selectedGrades.filter(g => g !== grade)
+      : [...selectedGrades, grade];
+    set({ selectedGrades: newGrades });
+  },
 
   getProblem: (params: GetProblemParams): Problem | null => {
     const { createProblemFromMapFeature } = get();


### PR DESCRIPTION
## Summary
- Add GradeFilter component with selectable V0-V9 grade badges
- Integrate grade filtering with map ProblemsLayer using Mapbox expressions 
- Update search functionality to respect selected grade filters
- Add grade filter state management to problemStore
- Position grade filter below search bar when search overlay is closed

## Test plan
- [ ] Verify grade filter UI appears below search bar on map screen
- [ ] Test selecting/deselecting individual grades filters problems on map
- [ ] Verify search results respect active grade filters
- [ ] Test "Clear" button removes all selected grades
- [ ] Confirm grade filter hides when search overlay or problem view is active

🤖 Generated with [Claude Code](https://claude.ai/code)